### PR TITLE
Fixed formatting of Bay description.

### DIFF
--- a/docs/bay/index.md
+++ b/docs/bay/index.md
@@ -1,9 +1,7 @@
 # Bay
 
 Bay is a fully managed platform and hosting environment that provides an open
-Platform as a Service model managed by SDP. It:
-- is an open-source hosting platform based on Lagoon.
-- allows agencies to build, test and deliver websites via the cloud.
+Platform as a Service model managed by SDP. It is an open-source hosting platform based on [Lagoon](https://github.com/amazeeio/lagoon) which allows agencies to build, test and deliver websites via the cloud.
 
 Bay is a Kubernetes-based (OpenShift) Docker container hosting platform with
 auto-scaling, auto-recovery and high-availability at core.


### PR DESCRIPTION
The formatting of the Bay description was a bit messed up. This PR changes it from a list to a sentence.

Screenshot of the problem:
<img width="720" alt="Screen Shot 2020-04-14 at 3 36 47 pm" src="https://user-images.githubusercontent.com/121107/79189749-ea8b0f00-7e65-11ea-9989-71cdfcd740f7.png">
